### PR TITLE
Support 0.1.0 alpha

### DIFF
--- a/.github/workflows/ci-alpha.yml
+++ b/.github/workflows/ci-alpha.yml
@@ -1,0 +1,44 @@
+name: CI (alpha)
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      REPOSITORY_NAME: ${{ secrets.DOCKER_HUB_USERNAME }}/gitpod-satysfi
+      TAG: 0.1.0-alpha
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: alpha
+          push: false
+          load: true
+          tags: ${{ env.REPOSITORY_NAME }}:${{ env.TAG }}
+          cache-from: type=gha,scope=${{ env.TAG }}
+          cache-to: type=gha,mode=max,scope=${{ env.TAG }}
+
+      - name: Run test
+        run: docker run --rm ${{ env.REPOSITORY_NAME }}:${{ env.TAG }} satysfi --help
+
+      - name: Push to Docker Hub
+        run: docker push ${{ env.REPOSITORY_NAME }}:${{ env.TAG }}
+        if: github.event_name != 'pull_request'

--- a/.github/workflows/ci-alpha.yml
+++ b/.github/workflows/ci-alpha.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build
         uses: docker/build-push-action@v2
         with:
-          context: alpha
+          context: ./alpha
           push: false
           load: true
           tags: ${{ env.REPOSITORY_NAME }}:${{ env.TAG }}

--- a/.github/workflows/ci-alpha.yml
+++ b/.github/workflows/ci-alpha.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build
         uses: docker/build-push-action@v2
         with:
-          context: ./alpha
+          context: "{{defaultContext}}:alpha"
           push: false
           load: true
           tags: ${{ env.REPOSITORY_NAME }}:${{ env.TAG }}

--- a/alpha/Dockerfile
+++ b/alpha/Dockerfile
@@ -1,0 +1,22 @@
+FROM ocaml/opam:ubuntu-22.04-ocaml-4.14 AS build
+
+RUN sudo apt-get update && sudo apt-get install -y \
+    autoconf \
+ && sudo rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/gfngfn/SATySFi
+
+WORKDIR /home/opam/SATySFi
+
+RUN git switch dev-0-1-0-separate-saphe-from-satysfi
+RUN opam repository add satysfi-external https://github.com/gfngfn/satysfi-external-repo.git
+RUN opam update && opam install -y . --deps-only
+RUN opam exec -- make all
+RUN opam install -y .
+
+FROM gitpod/workspace-base
+
+COPY --from=build /home/opam/SATySFi/satysfi /usr/local/bin/satysfi
+COPY --from=build /home/opam/SATySFi/saphe /usr/local/bin/saphe
+
+USER gitpod


### PR DESCRIPTION
Add support for SATySFi 0.1.0 alpha. Since SATySFi 0.1.0 has not been released at this time, the `dev-0-1-0-separate-saphe-from-satysfi` branch is specified directly.